### PR TITLE
Allow usage of incomplete pom models

### DIFF
--- a/org.eclipse.lsp4xml.extensions.maven/src/main/java/org/eclipse/lsp4xml/extensions/maven/MavenProjectCache.java
+++ b/org.eclipse.lsp4xml.extensions.maven/src/main/java/org/eclipse/lsp4xml/extensions/maven/MavenProjectCache.java
@@ -122,6 +122,12 @@ public class MavenProjectCache {
 				}
 			} else {
 				e.getResults().stream().flatMap(result -> result.getProblems().stream()).forEach(problems::add);
+				if (e.getResults().size() == 1) {
+					MavenProject project = e.getResults().get(0).getProject();
+					if (project != null) {
+						projectCache.put(uri, e.getResults().get(0).getProject());
+					}
+				}
 			}
 		} catch (ComponentLookupException | IOException | InvalidRepositoryException e) {
 			// TODO Auto-generated catch block


### PR DESCRIPTION
Some projectBuilder error still allow for manipulation of the model; in
such case, store the "incomplete" model for further usage as it reflects
a more current state anyway.

Signed-off-by: Mickael Istria <mistria@redhat.com>